### PR TITLE
add support for disabling vcr_cable with an environment variable

### DIFF
--- a/lib/vcr_cable.rb
+++ b/lib/vcr_cable.rb
@@ -26,7 +26,7 @@ module VcrCable
   end
 
   def enabled?
-    config.present?
+    config.present? && !config.fetch('disable_vcr_cable', false)
   end
 
   def reset_config
@@ -36,7 +36,7 @@ module VcrCable
   end
 
   def global_config
-    @global_config ||= File.file?(config_file) ? YAML.load_file(config_file) : DEFAULT_CONFIG
+    @global_config ||= File.file?(config_file) ? YAML.load(ERB.new(File.new(config_file).read).result) : DEFAULT_CONFIG
   end
 
   private

--- a/test/vcr_cable_test.rb
+++ b/test/vcr_cable_test.rb
@@ -13,6 +13,11 @@ class VcrCableTest < ActiveSupport::TestCase
     assert !VcrCable.enabled?
   end
 
+  test 'is not enabled when config disables it' do
+    VcrCable.stubs(:config).returns({'disable_vcr_cable' => true})
+    assert !VcrCable.enabled?
+  end
+
   test 'loads the default config when current env has configuration' do
     File.stubs(:file?).returns(false)
     VcrCable.stubs(:env).returns('development')


### PR DESCRIPTION
should resolve #3
I added support for parsing erb in the yml so that I could read in my environment variable.
When I run this in my app my config file looks like this:

```
development:
  hook_into: webmock
  cassette_library_dir: development_cassettes
  allow_http_connections_when_no_cassette: true
  disable_vcr_cable: <%= ENV['DISABLE_VCR_CABLE'] %>
```
