### PR TITLE
Allow partial configuration by merging local with default configuration

### DIFF
--- a/lib/generators/templates/vcr_cable.yml
+++ b/lib/generators/templates/vcr_cable.yml
@@ -2,3 +2,4 @@ development:
   hook_into: fakeweb
   cassette_library_dir: development_cassettes
   allow_http_connections_when_no_cassette: true
+  disable_vcr_cable: false

--- a/test/dummy/config/vcr_cable.yml
+++ b/test/dummy/config/vcr_cable.yml
@@ -1,9 +1,2 @@
 development:
-  hook_into: fakeweb
-  cassette_library_dir: development_cassettes
-  allow_http_connections_when_no_cassette: true
-
-test:
-  hook_into: fakeweb
   cassette_library_dir: custom_named_cassettes
-  allow_http_connections_when_no_cassette: false

--- a/test/vcr_cable_test.rb
+++ b/test/vcr_cable_test.rb
@@ -18,36 +18,28 @@ class VcrCableTest < ActiveSupport::TestCase
     assert !VcrCable.enabled?
   end
 
-  test 'loads the default config when current env has configuration' do
-    File.stubs(:file?).returns(false)
-    VcrCable.stubs(:env).returns('development')
-    VcrCable.configure_vcr
-    assert_match /development_cassettes$/, VCR.configuration.cassette_library_dir
-  end
-
   test 'has no config when the current env has no configuration' do
-    VcrCable.stubs(:env).returns('without_vcr_cable')
     assert !VcrCable.config.present?
   end
 
-  test 'config in config/vcr_cable.yml overwrites default values' do
+  test 'loads config from config/vcr_cable.yml over default values' do
+    VcrCable.stubs(:env).returns('development')
     VcrCable.configure_vcr
     assert_match /custom_named_cassettes$/, VCR.configuration.cassette_library_dir
   end
 
-  test 'global_config contains all env specific configs' do
-    %w[test development].each do |env_name|
-      VcrCable.global_config.keys.include?(env_name)
-    end
+  test 'loads default values when not specified in config/vcr_cable.yml' do
+    VcrCable.stubs(:env).returns('development')
+    VcrCable.configure_vcr
+    assert VcrCable.config['allow_http_connections_when_no_cassette']
   end
 
   test 'adds VCR::Middleware::Rack to the middleware stack' do
-    assert Rails.configuration.middleware.any? {|name| name == 'VCR::Middleware::Rack'}
+    list = Dir.chdir(Rails.root) {`bundle exec rake middleware RAILS_ENV=development`}
+    assert_match /VCR::Middleware::Rack/, list
   end
 
   test 'it does not add VCR::Middleware::Rack to environments that are not enabled' do
-    list = Dir.chdir(Rails.root) {`bundle exec rake middleware RAILS_ENV=no_vcr`}
-    assert_not_match /VCR::Middleware::Rack/, list
+    assert !Rails.configuration.middleware.any? {|name| name == 'VCR::Middleware::Rack'}
   end
-
 end


### PR DESCRIPTION
By merging the configuration read from `config/vcr_cable.yml` into the `DEFAULT_CONFIGURATION`, I have enabled "partial" configuration i.e. setting only the values you want to change from their defaults.

I also simplified the test suite by using `test` as the non-vcr_cable environment and `development` as the with-vcr_cable environment, which matches up with the description of the gem and the provided default configuration.

Thanks for making this cool resource. I look forward to your feedback!

**jmm**
