### PR TITLE
Rework env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,22 @@ bundle exec rails generate vcr_cable
 
 The file will be located in the ```config``` folder of your rails application.
 
-You can also disable vcr_cable by setting `DISABLE_VCR_CABLE=true` in your environment. This would allow each developer to opt into or out of vcr_cable on his/her own machine, for example.
+## Config via env
+
+You can also enable/disable vcr_cable by setting `ENABLE_VCR_CABLE=true` or `ENABLE_VCR_CABLE=false` in your environment. This would allow each developer to opt into or out of vcr_cable on his/her own machine, for example.
+
+## Extra
+
+If you use `vcr_cable` in development env I recommend enable http requests for webmock or fakeweb. Just create an initializer, for example:
+
+```ruby
+# config/initializers/webmock.rb
+
+WebMock.allow_net_connect!
+
+```
+
+It will prevent exceptions when you disable `vcr_cable`.
 
 ## Contributing
 

--- a/lib/vcr_cable.rb
+++ b/lib/vcr_cable.rb
@@ -27,15 +27,15 @@ module VcrCable
   end
 
   def config
-    @config ||= default_config.merge local_config
+    @config ||= default_config.merge(local_config).merge(env_config)
   end
 
   def enabled?
     config.present? && !config['disable_vcr_cable']
   end
 
-  def disabled_by_env?
-    %w(true 1).include?(ENV['DISABLE_VCR_CABLE'])
+  def enabled_by_env?
+    %w(true 1).include?(ENV['ENABLE_VCR_CABLE'])
   end
 
   def reset_config
@@ -66,11 +66,16 @@ module VcrCable
     @default_config ||= if DEFAULT_CONFIG.has_key? env
       DEFAULT_CONFIG[env].merge({
         'hook_into' => select_default_mocking_library,
-        'disable_vcr_cable' => disabled_by_env?
       })
     else
       {}
     end
+  end
+
+  def env_config
+    @env_config ||= {
+      'disable_vcr_cable' => !enabled_by_env?
+    }
   end
 
   def select_default_mocking_library


### PR DESCRIPTION
I replaced `DISABLE_VCR_CABLE` flag with `ENABLE_VCR_CABLE`.

Also I added highest priority for env config. It's handy when I want disable `vcr_cable` in yaml by default and add ability for enable it with env flag.