### PR TITLE
Rework env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ gem 'fakeweb' # or webmock
 
 *Note: You can choose between the FakeWeb and WebMock gems for faking web requests. If one of those gems is already loaded by your application it will be used automatically.*
 
+By default `vcr_cable` is disabled. So for launch it you need to run server with ENV variable `ENABLE_VCR_CABLE=true` like this:
+
+```bash
+ENABLE_VCR_CABLE=true bundle exec rails s
+```
+
+Or you can enable `vcr_cable` in yaml config per environment (check out section below).
+
 That's it! Now all external requests will hit the remote servers only one time, and the application will subsequently use the recorded data.
 
 ## Custom VCR Configuration
@@ -32,7 +40,7 @@ development:
   enable_erb: false
   allow_playback_repeats: false
   allow_http_connections_when_no_cassette: true
-  disable_vcr_cable: false
+  enable_vcr_cable: false
 ```
 
 If you want to override those values or configure vcr_cable to work in some
@@ -44,7 +52,19 @@ bundle exec rails generate vcr_cable
 
 The file will be located in the ```config``` folder of your rails application.
 
-You can also disable vcr_cable by setting `DISABLE_VCR_CABLE=true` in your environment. This would allow each developer to opt into or out of vcr_cable on his/her own machine, for example.
+## Config via env
+
+You can also enable/disable vcr_cable by setting `ENABLE_VCR_CABLE=true` or `ENABLE_VCR_CABLE=false` in your environment. This would allow each developer to opt into or out of vcr_cable on his/her own machine, for example.
+
+## Extra
+
+If you use `vcr_cable` in development env I recommend enable http requests for webmock or fakeweb. Just create an initializer, for example:
+
+```ruby
+WebMock.allow_net_connect! if defined? WebMock
+```
+
+It will prevent exceptions when you disable `vcr_cable`.
 
 ## Contributing
 

--- a/lib/generators/templates/vcr_cable.yml
+++ b/lib/generators/templates/vcr_cable.yml
@@ -4,4 +4,4 @@ development:
   enable_erb: false
   allow_playback_repeats: false
   allow_http_connections_when_no_cassette: true
-  disable_vcr_cable: false 
+  enable_vcr_cable: false

--- a/test/vcr_cable_test.rb
+++ b/test/vcr_cable_test.rb
@@ -3,23 +3,27 @@ require 'test_helper'
 class VcrCableTest < ActiveSupport::TestCase
   setup { VcrCable.reset_config }
 
-  test 'is enabled when config is present' do
-    VcrCable.stubs(:config).returns({:some => :conf})
+  test 'is disabled by default' do
+    assert !VcrCable.enabled?
+  end
+
+  test 'is enabled when config enables it' do
+    VcrCable.stubs(:config).returns({'enable_vcr_cable' => true})
     assert VcrCable.enabled?
   end
 
-  test 'is not enabled when config is not present' do
-    VcrCable.stubs(:config).returns({})
-    assert !VcrCable.enabled?
-  end
-
   test 'is not enabled when config disables it' do
-    VcrCable.stubs(:config).returns({'disable_vcr_cable' => true})
+    VcrCable.stubs(:config).returns({'enable_vcr_cable' => false})
     assert !VcrCable.enabled?
   end
 
-  test 'is not enabled when DISABLE_VCR_CABLE is present in ENV' do
-    ENV.stubs(:[]).with('DISABLE_VCR_CABLE').returns(true)
+  test 'is enabled when ENABLE_VCR_CABLE is present in ENV and set to true' do
+    ENV['ENABLE_VCR_CABLE'] = 'true'
+    assert VcrCable.enabled?
+  end
+
+  test 'is not enabled when ENABLE_VCR_CABLE is present in ENV and set to false' do
+    ENV['ENABLE_VCR_CABLE'] = 'false'
     assert !VcrCable.enabled?
   end
 
@@ -71,7 +75,7 @@ class VcrCableTest < ActiveSupport::TestCase
   end
 
   test 'adds VCR::Middleware::Rack to the middleware stack' do
-    list = Dir.chdir(Rails.root) {`bundle exec rake middleware RAILS_ENV=development`}
+    list = Dir.chdir(Rails.root) {`bundle exec rake middleware RAILS_ENV=development ENABLE_VCR_CABLE=true`}
     assert_match /VCR::Middleware::Rack/, list
   end
 


### PR DESCRIPTION
Now `vcr_cable` is disabled by default.

I replaced DISABLE_VCR_CABLE flag with ENABLE_VCR_CABLE.

Also I added highest priority for env config. It's handy when I want disable vcr_cable in yaml by default and add ability for enable it with env flag.
